### PR TITLE
Update CentOS8 and make vboxadd stay

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 
 Vagrant.configure(2) do |config|
     config.vm.define 'centos8-bare' do |centos|
-        centos.vm.box = 'centos8-bare'
+        centos.vm.box = 'centos8-bare-vb'
         centos.vm.synced_folder '.', '/vagrant'
         centos.vm.provider 'virtualbox' do |vb|
             vb.name = 'centos8-bare'

--- a/centos.json
+++ b/centos.json
@@ -98,8 +98,8 @@
   "variables": {
     "guest_additions": "disable",
     "iso_path": "/sw/centos",
-    "iso_name": "CentOS-8.3.2011-x86_64-boot.iso",
-    "iso_url": "https://mirrorlist.centos.org/pub/centos/8.3.2011/isos/x86_64/CentOS-8.3.2011-x86_64-boot.iso",
+    "iso_name": "CentOS-8.5.2111-x86_64-boot.iso",
+    "iso_url": "http://ftp.tu-chemnitz.de/pub/linux/centos/8.5.2111/isos/x86_64/CentOS-8.5.2111-x86_64-boot.iso",
     "kickstart": "kickstart.cfg",
     "proxy": "{{ env `http_proxy` }}"
   }

--- a/centos.json
+++ b/centos.json
@@ -97,8 +97,8 @@
   ],
   "variables": {
     "guest_additions": "disable",
-    "iso_name": "CentOS-8.3.2011-x86_64-boot.iso",
     "iso_path": "/sw/centos",
+    "iso_name": "CentOS-8.3.2011-x86_64-boot.iso",
     "iso_url": "https://mirrorlist.centos.org/pub/centos/8.3.2011/isos/x86_64/CentOS-8.3.2011-x86_64-boot.iso",
     "kickstart": "kickstart.cfg",
     "proxy": "{{ env `http_proxy` }}"

--- a/centos.json
+++ b/centos.json
@@ -40,13 +40,13 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "1024"
+          "4024"
         ],
         [
           "modifyvm",
           "{{.Name}}",
           "--cpus",
-          "2"
+          "4"
         ],
         [
           "modifyvm",

--- a/centos.json
+++ b/centos.json
@@ -24,7 +24,7 @@
       "hard_drive_interface": "sata",
       "headless": false,
       "http_directory": "http",
-      "iso_checksum": "sha256:2b801bc5801816d0cf27fc74552cf058951c42c7b72b1fe313429b1070c3876c",
+      "iso_checksum": "sha256:9602c69c52d93f51295c0199af395ca0edbe35e36506e32b8e749ce6c8f5b60a",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"

--- a/scripts/90virtualbox.sh
+++ b/scripts/90virtualbox.sh
@@ -16,4 +16,4 @@ mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
 sh /mnt/VBoxLinuxAdditions.run
 umount /mnt
 rm -rf /home/vagrant/VBoxGuestAdditions_*.iso
-
+systemctl enable vboxadd.service

--- a/vb.json
+++ b/vb.json
@@ -1,0 +1,5 @@
+{
+  "box_name": "centos8-bare-vb",
+  "disk_size": "16384",
+  "guest_additions": "upload"
+}


### PR DESCRIPTION
Thanks for the packer files to create and update a CentOS8 image. I updated the ISO version.

Another thing that I try to wrap my head around is how the vboxadd are sometimes work and sometimes they do not.
I'll open an issue to figure that one out. :) 